### PR TITLE
WasmKit: allow building with the host toolchain

### DIFF
--- a/utils/swift_build_support/swift_build_support/toolchain.py
+++ b/utils/swift_build_support/swift_build_support/toolchain.py
@@ -70,6 +70,7 @@ else:
     _register("ar", "ar")
 _register("sccache", "sccache")
 _register("swiftc", "swiftc")
+_register("swift_build", "swift-build")
 
 
 class Darwin(Toolchain):


### PR DESCRIPTION
For small local incremental builds that require WasmKit it's faster to build WasmKit with the host toolchain instead of waiting for a full bootstrap build to complete.