### PR TITLE
[NFC] wasmstdlib.py: fix Python typing error

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
@@ -236,7 +236,7 @@ class WasmStdlib(cmake_product.CMakeProduct):
         }
         self.test_with_cmake(None, [test_target], self._build_variant, [], test_env=env)
 
-    def should_test_executable(self):
+    def should_test_executable(self) -> bool:
         return True
 
     @property


### PR DESCRIPTION
Fix type error in `should_test_executable`:
```
reportIncompatibleMethodOverride: Method "should_test_executable" overrides class "WasmStdlib" in an incompatible manner
Return type mismatch: base method returns type "Literal[True]", override returns type "Literal[False]"
"Literal[False]" is not assignable to type "Literal[True]"
```