### PR TITLE
wasm-run.py: consistent `wasmkit` path with `build_runtime_with_host_compiler`

### DIFF
--- a/utils/wasm-run.py
+++ b/utils/wasm-run.py
@@ -24,7 +24,7 @@ class WASIRunner(object):
             subprocess.check_call(command)
 
     def invocation(self, args):
-        command = ["wasmkit-cli", "run"]
+        command = ["wasmkit", "run"]
         envs = collect_wasm_env()
         for key in envs:
             command.append("--env")


### PR DESCRIPTION
When passing `--build-runtime-with-host-compiler` there's no such executable `wasmkit-cli` in the host toolchain, where it's named `wasmkit` when installed. Let's make that consistent to make it work in both cases.